### PR TITLE
add_group_member_name

### DIFF
--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -2,9 +2,11 @@
   .chat-main__group-info
     .chat-main__group-info__name-box
       %p.group-name
-        test
+        = @group.name
       %p.group-member
-        Member：tamaru
+        = "Member : "
+        - @group.group_users.each do |member| 
+          = member.user.name
     .chat-main__group-info__edit-box
       =link_to "#", class: "edit-btn" do
         .edit-btn-box


### PR DESCRIPTION
#What
ヘッダーにグループ名とグループメンバーを表示できるように実装

#why
チャットのグループメンバーに所属するメンバーがわかる