### PR TITLE
add_group_edit_link

### DIFF
--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -8,7 +8,7 @@
         - @group.group_users.each do |member| 
           = member.user.name
     .chat-main__group-info__edit-box
-      =link_to "#", class: "edit-btn" do
+      =link_to edit_group_path(@group) , class: "edit-btn" do
         .edit-btn-box
           Edit
   .chat-main__message-list


### PR DESCRIPTION
#what
group編集リンクの作成

#why
グループ編集画面へ遷移させるため