### PR TITLE
add_redirect_link_after_edit_group

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -23,7 +23,7 @@ class GroupsController < ApplicationController
 
   def update 
     if @group.update(group_params)
-      redirect_to root_path, notice: 'グループを更新しました'
+      redirect_to group_messages_path(set_group) , notice: 'グループを更新しました'
     else
       render :edit
     end


### PR DESCRIPTION
#what
グループを編集後にグループメッセージが表示されている画面へ繊維するパスを実装

#why
ユーザーのリンクの効率化するため